### PR TITLE
Counting draws as a third of a win

### DIFF
--- a/Scripts/Imports/Functions/03-Metagame_Data_Treatment.R
+++ b/Scripts/Imports/Functions/03-Metagame_Data_Treatment.R
@@ -593,7 +593,7 @@ generate_matchup_data = function(df, chartShare, presence, archetype = NA){
   plotTableWR$ArchShare1 = paste0("<span style = 'font-size:10pt'><b>",
                                   plotTableWR$Archetype1,"</b></span>",
                                   "<br>Share: ",plotTableWR$Share,
-                                  " %<br>Win Rate: ",plotTableWR$WinRateArch,"%")
+                                  " %<br><b>Overall Win Rate: ",plotTableWR$WinRateArch,"</b>%")
   plotTableWR$Archetype2 = paste0("vs ",plotTableWR$Archetype2)
   
   plotTableWR$Archetype2 = factor(plotTableWR$Archetype2, 

--- a/Scripts/Imports/Functions/03-Metagame_Data_Treatment.R
+++ b/Scripts/Imports/Functions/03-Metagame_Data_Treatment.R
@@ -224,15 +224,15 @@ archetype_metrics = function(df, presence){
   metric_df$Presence = unlist(100 * metric_df[presence]/sum(metric_df[presence]))
   
   # Compute the win rate and confidence interval on it
-  metric_df$Measured.Win.Rate = metric_df$Wins * 100 / 
-    (metric_df$Wins + metric_df$Defeats)
+  metric_df$Measured.Win.Rate = (metric_df$Wins + metric_df$Draws / 3) * 100 /
+    metric_df$Matches
 
   # Aggregate wins and losses by player and archetype
   player_archetype_aggregates <- df %>%
     group_by(Player, Archetype$Archetype) %>%
-    summarise(TotalWins = sum(Wins),
+    summarise(TotalWins = sum(Wins) + sum(Draws) / 3,
               TotalLosses = sum(Losses),
-              TotalMatches = sum(Wins + Losses),
+              TotalMatches = sum(Wins + Losses + Draws),
               .groups = 'drop')
   # Compute win rates at this aggregated level
   player_archetype_aggregates <- player_archetype_aggregates %>%


### PR DESCRIPTION
Another point against UW control, "in paper it goes to time too often so it's not viable".

I updated the code to check if that was true. Although UW control goes to time 2.5x more than average (8.5% vs 3.2%), it still has n above than average winrate.

In this PR draws are counted as "one third of a win". IDK if this is something we want to count going forward?